### PR TITLE
fix: Arrumando a responsividade da seção de categorias

### DIFF
--- a/web-dev-project/src/components/CategoriasSection/style.js
+++ b/web-dev-project/src/components/CategoriasSection/style.js
@@ -27,9 +27,9 @@ export const Text = styled.div`
 
 export const Cards = styled.div`
     display: grid;
-    grid-template-columns: auto auto;
-    place-content: center;
+    grid-template-columns: auto auto auto auto;
     gap: 4vmax 4vmax;
+    place-content: center;
     
     width: 100%;
 
@@ -63,6 +63,12 @@ export const Cards = styled.div`
     #image {
         height: 12vmax;
         width: auto;
+    }
+
+    @media (max-width: 770px) {
+        grid-template-columns: auto auto;
+        gap: 4vmax 6vmax;
+        place-content: center;
     }
 `
 


### PR DESCRIPTION
## O que?
- A exibição da seção de categorias será feita em linha a menos que não caiba
- Caso a página tenha menos de 770px de largura, a exibição será feita em duas colunas