### PR TITLE
fix: arrumando position: Sticky na navbar

### DIFF
--- a/web-dev-project/src/app/globals.css
+++ b/web-dev-project/src/app/globals.css
@@ -15,8 +15,10 @@
 }
 
 html, body {
+    height: 100vh;
     width: 100%;
     overflow-x: hidden;
+    overflow-y: auto;
 }
 
 h1 {

--- a/web-dev-project/src/components/NavBar/styles.js
+++ b/web-dev-project/src/components/NavBar/styles.js
@@ -9,6 +9,7 @@ export const Content = styled.div`
     align-items: center;
     position: sticky;
     top: 0;
+    z-index: 1;
 
     #logo {
         margin: 1%;


### PR DESCRIPTION
## Problema
- A característica "position: sticky" da navBar não funcionava corretamente.

## Solução
- Isso ocorria pois o elemento pai não tinha altura definida
- Atribui "height: 100vh" e "overflow-y: auto" ao elemento "html"